### PR TITLE
docs:correct the typo

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -4,7 +4,7 @@
 
 <MudContainer Class="mt-16">
     <MudText Typo="Typo.h3" Align="Align.Center" GutterBottom="true">Learn to Cloud Dictionary</MudText>
-    <MudText Typo="Typo.body1" Align="Align.Center" GutterBottom="true">A list of all defintions in the LTC dictionary, click the button below to submit your own.</MudText>
+    <MudText Typo="Typo.body1" Align="Align.Center" GutterBottom="true">A list of all definitions in the LTC dictionary, click the button below to submit your own.</MudText>
    
     
     <MudContainer Class="d-flex align-center justify-center mud-width-full"  style="height:5vh;">


### PR DESCRIPTION
I corrected the spelling of "definitions" .